### PR TITLE
The user doesn't have to accept the GPL

### DIFF
--- a/warpinator.iss
+++ b/warpinator.iss
@@ -20,7 +20,7 @@ AppSupportURL={#MyAppURL}
 AppUpdatesURL={#MyAppURL}/releases
 DefaultDirName={autopf}\{#MyAppName}
 DisableProgramGroupPage=yes
-LicenseFile=LICENSE
+InfoBeforeFile=LICENSE
 ; Uncomment the following line to run in non administrative install mode (install for current user only.)
 ;PrivilegesRequired=lowest
 PrivilegesRequiredOverridesAllowed=commandline


### PR DESCRIPTION
Per the GPL's own text, you do not have to accept the GPL to run the program. Inno's LicenseFile flow requires you to accept the license to install the program, which is contradictory. This PR makes the GPLv3 an InfoBeforeFile rather than a LicenseFile, removing the need for the user to indicate acceptance.